### PR TITLE
Correctly check python2 in NeoVim

### DIFF
--- a/autoload/pyenv/python.vim
+++ b/autoload/pyenv/python.vim
@@ -9,7 +9,7 @@ let s:selected_major_version = 0
 
 " Private
 function! s:is_enabled() abort " {{{
-  return has('pythonx') || has('python2') || has('python3')
+  return has('pythonx') || has('python') || has('python3')
 endfunction " }}}
 
 function! s:get_external_version() abort " {{{


### PR DESCRIPTION
This fix a typo in pull request #29, I dunno why I committed that way, even if I've commented the correct code [here](https://github.com/lambdalisue/vim-pyenv/pull/28#issuecomment-386623168).