### PR TITLE
Use jedi parameter instead of dropped function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ to change the major version of jedi like
 ```vim
 if jedi#init_python()
   function! s:jedi_auto_force_py_version() abort
-    let major_version = pyenv#python#get_internal_major_version()
-    call jedi#force_py_version(major_version)
+    let g:jedi#force_py_version = pyenv#python#get_internal_major_version()
   endfunction
   augroup vim-pyenv-custom-augroup
     autocmd! *


### PR DESCRIPTION
Now, jedi does not support `jedi#force_py_version()` function.
Instead of that, we can use `g:jedi#force_py_version` variable.